### PR TITLE
Recover AudioRecord after audio server restart

### DIFF
--- a/android/app/src/main/java/com/example/ava/audio/MicrophoneInput.kt
+++ b/android/app/src/main/java/com/example/ava/audio/MicrophoneInput.kt
@@ -46,8 +46,11 @@ class MicrophoneInput(
         val audioRecord = this.audioRecord ?: error("Microphone not started")
         buffer.clear()
         val read = audioRecord.read(buffer, bufferSize)
+        if (read == AudioRecord.ERROR_DEAD_OBJECT) {
+            throw AudioRecordDeadObjectException()
+        }
         check(read >= 0) {
-            "error reading audio, read: $read"
+            "Error reading audio, read: $read"
         }
         buffer.limit(read)
         return buffer
@@ -97,20 +100,41 @@ class MicrophoneInput(
     }
 
     override fun close() {
-        
-        aec?.release()
+        try {
+            aec?.release()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to release acoustic echo canceler", e)
+        }
         aec = null
-        agc?.release()
+        try {
+            agc?.release()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to release automatic gain control", e)
+        }
         agc = null
-        ns?.release()
+        try {
+            ns?.release()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to release noise suppressor", e)
+        }
         ns = null
-        
-        audioRecord?.let {
-            if (isRecording) {
-                it.stop()
+
+        val record = audioRecord
+        audioRecord = null
+        record?.let {
+            try {
+                if (it.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
+                    it.stop()
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to stop AudioRecord", e)
+            } finally {
+                try {
+                    it.release()
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to release AudioRecord", e)
+                }
             }
-            it.release()
-            audioRecord = null
         }
     }
 
@@ -122,3 +146,7 @@ class MicrophoneInput(
         const val DEFAULT_AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT
     }
 }
+
+class AudioRecordDeadObjectException : IllegalStateException(
+    "AudioRecord is no longer valid because the audio server died"
+)

--- a/android/app/src/main/java/com/example/ava/esphome/voicesatellite/VoiceSatelliteAudioInput.kt
+++ b/android/app/src/main/java/com/example/ava/esphome/voicesatellite/VoiceSatelliteAudioInput.kt
@@ -1,17 +1,22 @@
 package com.example.ava.esphome.voicesatellite
 
 import android.Manifest
+import android.util.Log
 import androidx.annotation.RequiresPermission
+import com.example.ava.audio.AudioRecordDeadObjectException
 import com.example.ava.audio.MicrophoneInput
 import com.example.ava.microwakeword.WakeWordDetector
 import com.example.ava.microwakeword.WakeWordProvider
 import com.google.protobuf.ByteString
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.yield
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -71,7 +76,9 @@ class VoiceSatelliteAudioInput(
         
         if (it) emptyFlow()
         else flow {
-            val microphoneInput = MicrophoneInput()
+            var microphoneInput: MicrophoneInput? = null
+            var recoveringFromAudioServerDeath = false
+            var retryDelayMs = AUDIO_SERVER_RETRY_INITIAL_DELAY_MS
             var wakeWords = activeWakeWords.value
             var stopWords = activeStopWords.value
 
@@ -83,8 +90,31 @@ class VoiceSatelliteAudioInput(
                 setActiveWakeWords(stopWords)
             }
             try {
-                microphoneInput.start()
-                while (true) {
+                while (currentCoroutineContext().isActive) {
+                    if (microphoneInput == null) {
+                        var candidate: MicrophoneInput? = null
+                        try {
+                            val newMicrophone = MicrophoneInput()
+                            candidate = newMicrophone
+                            newMicrophone.start()
+                            microphoneInput = newMicrophone
+                        } catch (e: Exception) {
+                            candidate?.close()
+                            if (!recoveringFromAudioServerDeath) throw e
+
+                            Log.w(
+                                TAG,
+                                "Audio server is not ready; retrying microphone in ${retryDelayMs}ms",
+                                e
+                            )
+                            delay(retryDelayMs)
+                            retryDelayMs = (retryDelayMs * 2).coerceAtMost(
+                                AUDIO_SERVER_RETRY_MAX_DELAY_MS
+                            )
+                            continue
+                        }
+                    }
+
                     if (wakeWords != activeWakeWords.value) {
                         wakeWords = activeWakeWords.value
                         wakeWordDetector.setActiveWakeWords(wakeWords)
@@ -95,7 +125,32 @@ class VoiceSatelliteAudioInput(
                         stopWordDetector.setActiveWakeWords(stopWords)
                     }
 
-                    val audio = microphoneInput.read()
+                    val audio = try {
+                        checkNotNull(microphoneInput).read()
+                    } catch (e: AudioRecordDeadObjectException) {
+                        Log.w(
+                            TAG,
+                            "Audio server died; closing the invalid microphone before retrying",
+                            e
+                        )
+                        recoveringFromAudioServerDeath = true
+                        microphoneInput?.close()
+                        microphoneInput = null
+                        delay(retryDelayMs)
+                        retryDelayMs = (retryDelayMs * 2).coerceAtMost(
+                            AUDIO_SERVER_RETRY_MAX_DELAY_MS
+                        )
+                        continue
+                    }
+
+                    if (recoveringFromAudioServerDeath) {
+                        Log.i(TAG, "Microphone recovered after audio server restart")
+                        recoveringFromAudioServerDeath = false
+                        retryDelayMs = AUDIO_SERVER_RETRY_INITIAL_DELAY_MS
+                        wakeWordDetector.reset()
+                        stopWordDetector.reset()
+                    }
+
                     if (isStreaming) {
                         val volume = _microphoneVolume.value
                         if (volume != 1.0f) {
@@ -138,10 +193,16 @@ class VoiceSatelliteAudioInput(
                     yield()
                 }
             } finally {
-                microphoneInput.close()
+                microphoneInput?.close()
                 wakeWordDetector.close()
                 stopWordDetector.close()
             }
         }
+    }
+
+    companion object {
+        private const val TAG = "VoiceSatelliteAudioInput"
+        private const val AUDIO_SERVER_RETRY_INITIAL_DELAY_MS = 250L
+        private const val AUDIO_SERVER_RETRY_MAX_DELAY_MS = 5_000L
     }
 }

--- a/android/app/src/main/java/com/example/ava/services/VoiceSatelliteService.kt
+++ b/android/app/src/main/java/com/example/ava/services/VoiceSatelliteService.kt
@@ -90,9 +90,12 @@ class VoiceSatelliteService() : LifecycleService() {
         com.example.ava.settings.BrowserSettingsStore(applicationContext)
     }
     private var hideVinylJob: kotlinx.coroutines.Job? = null
+    private var settingsWatcherJob: kotlinx.coroutines.Job? = null
+    private var wakeLockRenewalRunnable: Runnable? = null
     private var voiceSatelliteNsd = AtomicReference<NsdRegistration?>(null)
     internal val _voiceSatellite = MutableStateFlow<VoiceSatellite?>(null)
     private val initializing = java.util.concurrent.atomic.AtomicBoolean(false)
+    private val restarting = java.util.concurrent.atomic.AtomicBoolean(false)
     
     
     private var cachedVinylCoverEnabled = false
@@ -260,6 +263,10 @@ class VoiceSatelliteService() : LifecycleService() {
             .putBoolean("service_user_stopped", true)
             .apply()
         
+        settingsWatcherJob?.cancel()
+        settingsWatcherJob = null
+        stopWakeLockRenewal()
+
         val satellite = _voiceSatellite.getAndUpdate { null }
         if (satellite != null) {
             satellite.close()
@@ -274,12 +281,16 @@ class VoiceSatelliteService() : LifecycleService() {
     
     fun restartVoiceSatellite() {
         
-        if (_voiceSatellite.value == null) return
+        if (_voiceSatellite.value == null || !restarting.compareAndSet(false, true)) return
         
         lifecycleScope.launch {
-            stopVoiceSatellite()
-            kotlinx.coroutines.delay(500) 
-            startVoiceSatellite()
+            try {
+                stopVoiceSatellite()
+                kotlinx.coroutines.delay(500)
+                startVoiceSatellite()
+            } finally {
+                restarting.set(false)
+            }
         }
     }
     
@@ -506,7 +517,8 @@ class VoiceSatelliteService() : LifecycleService() {
     }
 
     private fun startSettingsWatcher() {
-        lifecycleScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+        settingsWatcherJob?.cancel()
+        settingsWatcherJob = lifecycleScope.launch(kotlinx.coroutines.Dispatchers.IO) {
             _voiceSatellite.flatMapLatest { satellite ->
                 if (satellite == null) emptyFlow()
                 else merge(
@@ -987,6 +999,9 @@ class VoiceSatelliteService() : LifecycleService() {
     
     override fun onDestroy() {
         instance = null
+        settingsWatcherJob?.cancel()
+        settingsWatcherJob = null
+        stopWakeLockRenewal()
         _voiceSatellite.getAndUpdate { null }?.close()
         voiceSatelliteNsd.getAndSet(null)?.unregister(this)
         wifiWakeLock.release()
@@ -1013,6 +1028,7 @@ class VoiceSatelliteService() : LifecycleService() {
         
         RootHelper.removeBootScript()
         initializing.set(false)
+        restarting.set(false)
         super.onDestroy()
     }
     
@@ -1022,7 +1038,8 @@ class VoiceSatelliteService() : LifecycleService() {
     private val WAKELOCK_RENEWAL_INTERVAL = 25 * 60 * 1000L
     
     private fun startWakeLockRenewal() {
-        updateCheckHandler.postDelayed(object : Runnable {
+        stopWakeLockRenewal()
+        val runnable = object : Runnable {
             override fun run() {
                 if (_voiceSatellite.value != null) {
                     wifiWakeLock.renewIfNeeded()
@@ -1030,7 +1047,14 @@ class VoiceSatelliteService() : LifecycleService() {
                     updateCheckHandler.postDelayed(this, WAKELOCK_RENEWAL_INTERVAL)
                 }
             }
-        }, WAKELOCK_RENEWAL_INTERVAL)
+        }
+        wakeLockRenewalRunnable = runnable
+        updateCheckHandler.postDelayed(runnable, WAKELOCK_RENEWAL_INTERVAL)
+    }
+
+    private fun stopWakeLockRenewal() {
+        wakeLockRenewalRunnable?.let(updateCheckHandler::removeCallbacks)
+        wakeLockRenewalRunnable = null
     }
     
     private fun startAutoUpdateChecker() {


### PR DESCRIPTION
## Summary

Make continuous microphone capture recover when Android reports that its `AudioRecord` became invalid because the audio server died.

- Treat `AudioRecord.ERROR_DEAD_OBJECT` as a specific recoverable condition.
- Close the invalid recorder and its audio effects defensively.
- Recreate the recorder with bounded exponential backoff.
- Reset the wake/stop detectors after recording resumes.
- Serialize service restarts and cancel the previous settings watcher and wake-lock renewal callback before creating replacements.

## Faulty path

`MicrophoneInput.read()` currently does this for every negative result:

```kotlin
val read = audioRecord.read(buffer, bufferSize)
check(read >= 0)
```

Android documents `ERROR_DEAD_OBJECT` separately and requires the `AudioRecord` instance to be recreated. The generic check throws out of `VoiceSatelliteAudioInput.start()`, terminating its long-lived capture flow with no retry.

Android source documentation: https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android11-release/media/java/android/media/AudioRecord.java#114

The restart cleanup also prevents repeated settings changes or recovery attempts from accumulating permanent settings collectors and `Handler` callbacks.

## Related platform defect

This improves Ava recovery but does not replace the platform fix that prompted the investigation. LineageOS 18.1 has an upstream-fixed signed overflow in `AudioFlinger::RecordThread`; the corresponding CROWN/Amazon backport is proposed separately in amazon-oss/patches#1.

On the affected CROWN build, restarting Ava alone did not restore the vendor audio stack after `audioserver` aborted. Preventing that abort remains the OS-level fix.

## Verification

- Modified Kotlin sources parse successfully.
- `git diff --check` passes.
- Error handling preserves cancellation and caps retry delay at five seconds.

A full Gradle compile was not available on the test host because it has no Java runtime. Also, current public `master` imports `com.example.ava.esphome.voicesatellite.VoiceSatellite`, but that source is not present in the tracked tree, so a clean public checkout currently needs that missing source before it can compile.